### PR TITLE
chg: 初音ミク V6 発売に伴う記事更新

### DIFF
--- a/content/blog/dtm/hatsune-miku-comparison.md
+++ b/content/blog/dtm/hatsune-miku-comparison.md
@@ -1,6 +1,6 @@
 ---
 createdAt: "2024/08/01"
-updatedAt: "2026/02/20"
+updatedAt: "2026/04/26"
 title: "【2026年版】初音ミク 音声合成ソフト比較【V6・V4X・NT】"
 description: "初音ミクの音声合成ソフトについて価格・機能・歌声を比較します。"
 category: "DTM"
@@ -14,8 +14,7 @@ isRecommend: true
 
 ## はじめに
 
-[初音ミクの音声合成ソフトは、**V2**、**V3**、**V4X**、**NT**、**V6**の5種類]{.marker}が存在します。
-（**初音ミク V6**は2026年4月14日に発売）
+[初音ミクの音声合成ソフトは、**V6**、**NT**、**V4X**、**V3**、**V2**の5種類]{.marker}が存在します。
 また、初音ミクを含む音声合成ソフトとしては**ピアプロキャラクターズ・スーパーパック**もあります。
 
 これだけ種類が多いと、[どのソフトを選べばいいのか悩む方]{.marker}も多いのではないでしょうか。
@@ -26,14 +25,14 @@ isRecommend: true
 
 まずは、[発売日や価格などの基本スペック]{.marker}についてまとめました。
 
-| ソフト名                                                                                                                                         | 発売日     | 価格<br>（税込）                                   | 英語 | 歌声ライブラリ                                               | エディタ                 | 対応OS         | 備考                                 |
-| ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------- | -------------------------------------------------- | ---- | ------------------------------------------------------------ | ------------------------ | -------------- | ------------------------------------ |
-| [初音ミク V2](https://ec.crypton.co.jp/pages/prod/virtualsinger/cv01)<br>（[アペンド](https://ec.crypton.co.jp/pages/prod/virtualsinger/cv01a)） | 2007/8/31  | ￥16,500<br>アペンド:￥17,600                      | ❌️  | ORIGINAL<br>DARK<br>SWEET<br>SOFT<br>SOLID<br>LIGHT<br>VIVID | VOCALOID2 Editor         | Windows        | アペンド別売                         |
-| [初音ミク V3](https://ec.crypton.co.jp/pages/prod/virtualsinger/mikuv3)                                                                          | 2013/9/26  | ¥17,600                                            | ⭕️   | ORIGINAL<br>DARK<br>SWEET<br>SOFT<br>SOLID<br>ENGLISH        | Piapro Studio            | Windows<br>Mac |                                      |
-| [初音ミク V4X](https://ec.crypton.co.jp/pages/prod/virtualsinger/mikuv4x)                                                                        | 2016/8/31  | ￥17,600                                           | ⭕️   | ORIGINAL<br>DARK<br>SWEET<br>SOFT<br>SOLID<br>ENGLISH        | Piapro Studio<br>for V4X | Windows<br>Mac | <br>中国語版あり<br>クロスシンセシス |
-| [初音ミク V6](https://sonicwire.com/product/virtualsinger/special/miku-v6)                                                                       | 2026/4/14  | スターターパック:￥24,200<br>ボイスバンク:￥10,780 | ⭕️   | ORIGINAL<br>（日本語・英語・中国語）<br>未定                 | VOCALOID6 Editor         | Windows<br>Mac | VOCALOID:AI                          |
-| [初音ミク NT](https://ec.crypton.co.jp/pages/prod/virtualsinger/mikunt)                                                                          | 2020/11/27 | ¥19,800                                            | ❌️  | ORIGINAL<br>DARK<br>WHISPER                                  | Piapro Studio<br>for NT  | Windows<br>Mac | Automatic Control                    |
-| [ピアプロ<br>キャラクターズ<br>・<br>スーパーパック](https://ec.crypton.co.jp/pages/prod/virtualsinger/superpack)                                | 2024/8/30  | ¥23,100                                            | ❌️  | ORIGINAL                                                     | Piapro Studio<br>for V4X | Windows<br>Mac | バンドル版                           |
+| ソフト名                                                                                                                                                                                                                                                   | 発売日     | 価格<br>（税込）                                   | 英語 | 歌声ライブラリ                                                           | エディタ                 | 対応OS         | 備考                                 |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | -------------------------------------------------- | ---- | ------------------------------------------------------------------------ | ------------------------ | -------------- | ------------------------------------ |
+| <a href="https://ec.crypton.co.jp/pages/prod/virtualsinger/mikuv6" target="_blank" rel="noopener noreferrer">初音ミク V6</a>                                                                                                                               | 2026/4/14  | スターターパック:￥24,200<br>ボイスバンク:￥10,780 | ⭕️   | ORIGINAL<br>SOFT<br>（日本語・英語<br>中国語は<br>無料アップデート予定） | VOCALOID6 Editor         | Windows<br>Mac | VOCALOID:AI                          |
+| <a href="https://ec.crypton.co.jp/pages/prod/virtualsinger/mikunt" target="_blank" rel="noopener noreferrer">初音ミク NT</a>                                                                                                                               | 2020/11/27 | ¥19,800                                            | ❌️  | ORIGINAL<br>DARK<br>WHISPER                                              | Piapro Studio<br>for NT  | Windows<br>Mac | Automatic Control                    |
+| <a href="https://ec.crypton.co.jp/pages/prod/virtualsinger/mikuv4x" target="_blank" rel="noopener noreferrer">初音ミク V4X</a>                                                                                                                             | 2016/8/31  | ￥17,600                                           | ⭕️   | ORIGINAL<br>DARK<br>SWEET<br>SOFT<br>SOLID<br>ENGLISH                    | Piapro Studio<br>for V4X | Windows<br>Mac | <br>中国語版あり<br>クロスシンセシス |
+| <a href="https://ec.crypton.co.jp/pages/prod/virtualsinger/mikuv3" target="_blank" rel="noopener noreferrer">初音ミク V3</a>                                                                                                                               | 2013/9/26  | ¥17,600                                            | ⭕️   | ORIGINAL<br>DARK<br>SWEET<br>SOFT<br>SOLID<br>ENGLISH                    | Piapro Studio            | Windows<br>Mac |                                      |
+| <a href="https://ec.crypton.co.jp/pages/prod/virtualsinger/cv01" target="_blank" rel="noopener noreferrer">初音ミク V2</a><br>（<a href="https://ec.crypton.co.jp/pages/prod/virtualsinger/cv01a" target="_blank" rel="noopener noreferrer">アペンド</a>） | 2007/8/31  | ￥16,500<br>アペンド:￥17,600                      | ❌️  | ORIGINAL<br>DARK<br>SWEET<br>SOFT<br>SOLID<br>LIGHT<br>VIVID             | VOCALOID2 Editor         | Windows        | アペンド別売                         |
+| <a href="https://ec.crypton.co.jp/pages/prod/virtualsinger/superpack" target="_blank" rel="noopener noreferrer">ピアプロ<br>キャラクターズ<br>・<br>スーパーパック</a>                                                                                     | 2024/8/30  | ¥23,100                                            | ❌️  | ORIGINAL                                                                 | Piapro Studio<br>for V4X | Windows<br>Mac | バンドル版                           |
 
 基本的にはヤマハが開発した**VOCALOIDエンジン**ですが、[NTのみ**クリプトン**と**産業技術総合研究所**が開発した別の歌声合成エンジン]{.marker}となっています。
 
@@ -46,6 +45,39 @@ isRecommend: true
 ## エディタについて
 
 歌声を打ち込むときに使用する**エディタ**は、ソフトによって同梱されるものが異なります。
+
+### VOCALOID6
+
+**VOCALOID6**は初音ミク V6のスターターパックに同梱されるエディタです。
+別売で単体購入もできます。
+
+なお、ボイスバンク単体にはフル機能版ではなく、機能制限版の**VOCALOID6 Editor Lite**が付属します。
+
+:link-card{url="https://www.vocaloid.com/vocaloid6/buy/"}
+
+初音ミク NTを除くVOCALOID3以降の歌声ライブラリを読み込めます。
+
+VOCALOID6ではVOCALOID:AIを駆使した歌声合成エンジンにより、[歌詞とメロディーを入力するだけで自然な歌声を生成]{.marker}できます。
+
+ピアノロール上にはピッチカーブも表示されるため、直感的に編集が可能です。
+**Expressionパラメーター**による声のハリの調整や、ニュアンスの異なるボーカルを複数生成する**TAKE機能**も搭載されています。
+
+### Piapro Studio for NT
+
+**Piapro Studio for NT**は、初音ミクNTに同梱されるエディタです。
+
+UIはPiapro Studioと似ていますが、[音声波形表示やオートメーショントラックのオーバーレイといった新機能も搭載]{.marker}されています。
+変更できるパラメータもNT独自のものになっています。
+
+Ver.2からは好みの歌い方を簡単に実現できる**Automatic Control**も新たに搭載されています。
+
+:you-tube-iframe{title="『初音ミク NT (Ver.2)』歌声デモンストレーション（未調声・Automatic Controlのみ適用）" videoId="0BKG3uFC_Vw"}
+
+ただし、[VOCALOIDエンジンの歌声ライブラリを読み込むことはできません]{.marker}。
+vsqやvsqxファイルは読み込むことができますが、一部発音の変換が行われます。（[参考](https://piaprostudio.com/?p=8203)）
+
+Piapro Studio for NTに対応した歌声ライブラリは初音ミク NTと鏡音リン・レン NTだけです。
+他の歌声ライブラリを使用したい場合はNTを選ばない方がいいでしょう。
 
 ### Piapro Studio、Piapro Studio for V4X
 
@@ -72,66 +104,35 @@ Piapro Studio for V4Xでは、以下の機能を使用できます。
 また、Piapro Studio、Piapro Studio for V4Xは[プラグイン形式]{.marker}のため、起動にはVSTやVUプラグインに対応した[DAWソフトが必要]{.marker}となります。
 （スタンドアローン版は初音ミク V4 Chineseにだけは付属されるようです）
 
-### Piapro Studio for NT
-
-**Piapro Studio for NT**は、初音ミクNTに同梱されるエディタです。
-
-UIはPiapro Studioと似ていますが、[音声波形表示やオートメーショントラックのオーバーレイといった新機能も搭載]{.marker}されています。
-変更できるパラメータもNT独自のものになっています。
-
-Ver.2からは好みの歌い方を簡単に実現できる**Automatic Control**も新たに搭載されています。
-
-:you-tube-iframe{title="『初音ミク NT (Ver.2)』歌声デモンストレーション（未調声・Automatic Controlのみ適用）" videoId="0BKG3uFC_Vw"}
-
-ただし、[VOCALOIDエンジンの歌声ライブラリを読み込むことはできません]{.marker}。
-vsqやvsqxファイルは読み込むことができますが、一部発音の変換が行われます。（[参考](https://piaprostudio.com/?p=8203)）
-
-Piapro Studio for NTに対応した歌声ライブラリは初音ミク NTと鏡音リン・レン NTだけです。
-他の歌声ライブラリを使用したい場合はNTを選ばない方がいいでしょう。
-
-### VOCALOID6
-
-**VOCALOID6**は初音ミク V6はのスターターパックに同梱されるエディタです。
-別売で単体購入もできます。
-
-:link-card{url="https://www.vocaloid.com/vocaloid6/buy/"}
-
-初音ミク NTを除くVOCALOID3以降の歌声ライブラリを読み込めます。
-
-VOCALOID6ではVOCALOID:AIを駆使した歌声合成エンジンにより、[歌詞とメロディーを入力するだけで自然な歌声を生成]{.marker}できます。
-
-ピアノロール上にはピッチカーブも表示されるため、直感的に編集が可能です。
-**Expressionパラメーター**による声のハリの調整や、ニュアンスの異なるボーカルを複数生成する**TAKE機能**も搭載されています。
-
 ## デモソング
 
 [歌声を比較するために、デモソングをまとめました]{.marker}。
 デモソングによっては複数の歌声ライブラリを使用しているものもあるため、注意してください。
 
-### 初音ミク V2
+### 初音ミク V6
 
-:you-tube-iframe{title="初音ミク「ballade」" videoId="zQ7xqGhdX30"}
+:you-tube-iframe{title="『初音ミク V6』歌声デモンストレーション（プリズム）" videoId="gt-FIOgULQM"}
+
+### 初音ミクNT（Ver.2）
+
+:you-tube-iframe{title="『初音ミク NT (Ver.2)』歌声デモンストレーション" videoId="wIMhsHlTLso"}
+
+### 初音ミク V4X
+
+:you-tube-iframe{title="【初音ミクV4X】 ヒアミー 【歌声デモ】" videoId="5B6CrCOdIik"}
 
 ### 初音ミク V3
 
 :you-tube-iframe{title="[HATSUNE MIKU V3] Six Greetings（Short ver.） by きくお [初音ミク V3]
 " videoId="CWtHv3Lih_0"}
 
-### 初音ミク V4X
+### 初音ミク V2
 
-:you-tube-iframe{title="【初音ミクV4X】 ヒアミー 【歌声デモ】" videoId="5B6CrCOdIik"}
-
-### 初音ミク V6
-
-:you-tube-iframe{title="『初音ミク V6』歌声デモンストレーション（プリズム）" videoId="gt-FIOgULQM"}
+:you-tube-iframe{title="初音ミク「ballade」" videoId="zQ7xqGhdX30"}
 
 ### スーパーパック
 
 :you-tube-iframe{title="Step by Step（6 Singer Version） / Twinfield feat. 初音ミク & 鏡音リン & 鏡音レン & 巡音ルカ & MEIKO & KAITO" videoId="9zMgjlYHiOw"}
-
-### 初音ミクNT（Ver.2）
-
-:you-tube-iframe{title="『初音ミク NT (Ver.2)』歌声デモンストレーション" videoId="wIMhsHlTLso"}
 
 ### 歌声比較
 
@@ -146,11 +147,9 @@ VOCALOID6ではVOCALOID:AIを駆使した歌声合成エンジンにより、[�
 
 一番のオススメは、[初音ミク V6]{.marker}です。
 
-2026年4月14日に発売予定の初音ミク V6は、[VOCALOID:AIによる自然な歌声、日本語・英語・中国語対応、Cubase LE付属]{.marker}と、機能面で最も充実しています。
+2026年4月14日に発売された初音ミク V6は、[VOCALOID:AIによる自然な歌声、日本語・英語対応（中国語は無料アップデート予定）、Cubase LE付属]{.marker}と、機能面で最も充実しています。
 〈スターターパック〉（24,200円）を購入すればエディタも付属するため、これ1つで本格的な音楽制作を始められます。
 [過去のクリプトン製品を持っている場合は優待価格]{.marker}で購入できるのもポイントです。
-
-すぐに使いたい場合は、[初音ミク V4X]{.marker}もオススメです。
 
 基本的には[後発の音声合成ソフトの方が機能が豊富で、サポートが長い可能性も高い]{.marker}です。
 
@@ -169,13 +168,16 @@ NTについては、[新規に開発された音声合成エンジンのため�
 
 ::point-list{title="初音ミク購入時のポイント"}
 
-- [一番のオススメは、**初音ミク V6**]{.marker}（2026年4月14日発売予定、予約受付中）
-- すぐに使いたい場合は、**V4X**もオススメ
+- [一番のオススメは、**初音ミク V6**]{.marker}
 - 他のクリプトン製シンガーも欲しい場合は、**ピアプロキャラクターズ・スーパーパック**もあり
 
 ::
 
 参考になれば幸いです。
+
+:affiliate-block{title="初音ミク V6 スターターパック" imageUrl="https://m.media-amazon.com/images/I/71yXwJlmcqL._SL160_.jpg" asin="B0GNYVN7RN"}
+
+:affiliate-block{title="初音ミク V6 ボイスバンク" imageUrl="https://m.media-amazon.com/images/I/617yOUbYNsL._SL160_.jpg" asin="B0GNZD3LW3"}
 
 :affiliate-block{title="初音ミク V4X (incl. ENGLISH)" imageUrl="https://m.media-amazon.com/images/I/41K2VF40TYL._SL160_.jpg" asin="B0D7MDZF5L"}
 


### PR DESCRIPTION
## Summary

- 初音ミク V6（2026/4/14発売）の情報を反映
- 比較表を発売日の降順に並び替え
- テーブル内のリンクを別タブで開くよう変更
- V6 スターターパック / ボイスバンクのアフィリエイトブロックを追加