### PR TITLE
fix: X埋め込み動画のmp4を403解消 / OGP APIのCloudflare 500修正ほか

### DIFF
--- a/app/components/content/XEmbed.vue
+++ b/app/components/content/XEmbed.vue
@@ -38,6 +38,7 @@ function formatJaDatetime(createdAt: Date): string {
                 photos,
                 video,
                 tweetUrl,
+                proxyImage,
             }"
         >
             <a
@@ -116,7 +117,7 @@ function formatJaDatetime(createdAt: Date): string {
                         <source
                             v-for="variant in video.variants"
                             :key="variant.src"
-                            :src="variant.src"
+                            :src="proxyImage(variant.src)"
                             :type="variant.type"
                         />
                     </video>


### PR DESCRIPTION
## Summary

- X埋め込み動画のmp4 URLが生の `video.twimg.com` 直リンクのままでRefererブロックにより403になっていた問題を、`proxyImage` ヘルパー経由(x-imageプロキシ)に通して解消
- OGP APIをfetch+node-html-parserに置き換えてCloudflareでの500を修正
- @nuxt/scripts 導入によるX埋め込みのSSR移行、YouTube埋め込み関連の調整、lazy hydration系の試行とrevertを含む