### PR TITLE
upd: Synthesizer V 歌声データベース一覧を更新

### DIFF
--- a/content/blog/dtm/synthesizer-v-singer.md
+++ b/content/blog/dtm/synthesizer-v-singer.md
@@ -1,6 +1,6 @@
 ---
 createdAt: "2023/10/02"
-updatedAt: "2026/03/22"
+updatedAt: "2026/06/19"
 title: "Synthesizer V歌声データベース一覧！発売予定やオススメを紹介【Synthesizer V 2対応】"
 description: "Synthesizer Vの歌声データベースを一覧にして紹介しています。また、選び方やオススメの歌声データベースも紹介しています。"
 category: "DTM"

--- a/content/data/synthesizer-v-singer.csv
+++ b/content/data/synthesizer-v-singer.csv
@@ -1,4 +1,14 @@
 release,name,version,language,gender,company,voice,illust,image_url,dlsite_url
+2026/06/30,ANRI Requiem,2,英語,女声,AUDIOLOGIE,非公開,あり,,
+2026/06/30,ANDI Vesper,2,英語,男声,AUDIOLOGIE,非公開,あり,,
+2026/05/28,Marvin,2,英語,男声,Dreamtonics株式会社,非公開,なし,,
+2026/05/28,Nea,2,韓国語,女声,Dreamtonics株式会社,非公開,なし,https://img.dlsite.jp/modpub/images2/work/professional/VJ01007000/VJ01006416_img_main.webp,https://www.dlsite.com/soft/work/=/product_id/VJ01006416.html
+2026/05/28,Toi,2,韓国語,男声,Dreamtonics株式会社,非公開,なし,https://img.dlsite.jp/modpub/images2/work/professional/VJ01007000/VJ01006417_img_main.webp,https://www.dlsite.com/soft/work/=/product_id/VJ01006417.html
+2026/05/28,Lina,2,日本語,女声,Dreamtonics株式会社,非公開,なし,https://img.dlsite.jp/modpub/images2/work/professional/VJ01007000/VJ01006414_img_main.webp,https://www.dlsite.com/soft/work/=/product_id/VJ01006414.html
+2026/05/28,Shun,2,日本語,男声,Dreamtonics株式会社,非公開,なし,https://img.dlsite.jp/modpub/images2/work/professional/VJ01007000/VJ01006415_img_main.webp,https://www.dlsite.com/soft/work/=/product_id/VJ01006415.html
+2026/04/24,Sylva,2,英語,女声,Dreamtonics株式会社,非公開,なし,,
+2026/04/24,Aurielle,2,英語,女声,Dreamtonics株式会社,非公開,なし,,
+2026/03/26,Takumi,2,日本語,男声,Dreamtonics株式会社,石田匠,なし,https://img.dlsite.jp/modpub/images2/work/professional/VJ01007000/VJ01006104_img_main.webp,https://www.dlsite.com/soft/work/=/product_id/VJ01006104.html
 2026/03/05,花隈千冬,2,日本語,女声,株式会社 AHS,奥野香耶,あり,https://img.dlsite.jp/modpub/images2/work/professional/VJ01006000/VJ01005817_img_main.webp,https://www.dlsite.com/soft/work/=/product_id/VJ01005817.html
 2026/03/05,夏色花梨,2,日本語,女声,株式会社 AHS,高木美佑,あり,https://img.dlsite.jp/modpub/images2/work/professional/VJ01006000/VJ01005816_img_main.webp,https://www.dlsite.com/soft/work/=/product_id/VJ01005816.html
 2026/03/05,小春六花,2,日本語,女声,株式会社 AHS,青山吉能,あり,https://img.dlsite.jp/modpub/images2/work/professional/VJ01006000/VJ01005815_img_main.webp,https://www.dlsite.com/soft/work/=/product_id/VJ01005815.html


### PR DESCRIPTION
## Summary

- synthesizer-v-singer.csv に 2026年3月〜6月の新規歌声DB 10件を追加
  - Takumi (2026/03/26, Dreamtonics, 石田匠)
  - Aurielle, Sylva (2026/04/24, Dreamtonics, 英語)
  - Shun, Lina, Toi, Nea, Marvin (2026/05/28, Dreamtonics)
  - ANRI Requiem, ANDI Vesper (2026/06/30, AUDIOLOGIE, 発売予定)
- Shun / Lina / Toi / Nea の DLsite URL・画像 URL を追加
- updatedAt を 2026/06/19 に更新